### PR TITLE
Modifying resolved instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Added
 
 - Add `populate` method to register services
+- Add `modify` option to allow resolved objects to be modified before being
+  returned by the container
 
 ## 0.1.4
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,29 @@ $container->set(K::class)
 **NOTE.** Aliases apply to the constructor and *all* setter methods.  You
 cannot define aliases that only applies to a particular setter method.
 
+#### Modifying resolved instances
+
+In addition to setter injection, LightContainer supports other forms of
+modifying the resolved object before passing it back to the caller.
+
+To do this, create an instance of a class that implements
+`LightContainer\InstanceModifierInterface`, then pass it to the
+container using the `modify` method.
+
+```php
+class Modifier implements InstanceModifierInterface {
+    public function modify(object $obj, LightContainerInterface $container): object {}
+}
+
+class ModifyMe {}
+
+$modifier = new Modifier();
+$container->set(ModifyMe::class)->modify($modifier);
+
+// The container will call $modifier->modify() before returning the instance
+$modify_me = $container->get(ModifyMe::class);
+```
+
 #### Shared instances
 
 There may be times where you want the same instance of a class to
@@ -651,6 +674,7 @@ options (apart from `propagate`) are also available for
 | [`alias`](#aliases)                             | none                                                         | Aliases for type hinted arguments for the constructor and setter methods |
 | [`args`](#constructor-arguments)                | none                                                         | Set other arguments for the constructor                      |
 | [`call`](#setter-injection)                     | none                                                         | Call setter methods                                          |
+| [`modify`](#modifying-resolved-instances)       | none                                                         | Modify resolved instances                                    |
 | [`propagate`](#options-for-autowired-resolvers) | true                                                         | Whether instantiation options will propagate to autowired resolvers for subclasses |
 | [`shared`](#shared-instances)                   | false (except for [named instances](#multiple-shared-instances)) | Whether the instance resolved is shared across the container |
 

--- a/docs/configuration_format.md
+++ b/docs/configuration_format.md
@@ -68,6 +68,7 @@ The configuration array only supports a subset to LightContainer's features.
 **Not supported**
 
 * ❎ Specifying references to callables or objects
+* ❎ Specifying modifiers using the `modify` instantiation option
 * ❎ Custom instantiation
 * ❎ Configuring services using `populate`
 

--- a/src/InstanceModifierInterface.php
+++ b/src/InstanceModifierInterface.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * LightContainer
+ *
+ * Copyright (C) Kelvin Mo 2022
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. The name of the author may not be used to endorse or promote
+ *    products derived from this software without specific prior
+ *    written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ * OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+ * IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace LightContainer;
+
+use LightContainer\Resolvers\BaseInstanceResolver;
+
+/**
+ * An interface for instance modifiers.
+ * 
+ * A modifier is an object that modifies an instance of a object resolved
+ * by the container.
+ * 
+ * @see BaseInstanceResolver::modify()
+ */
+interface InstanceModifierInterface {
+    /**
+     * Modifies the resolved object.
+     * 
+     * The method receives the object that has been resolved in the first
+     * parameter and an instance of the container in the second
+     * parameter.  The method should return the modified object.
+     * 
+     * @param object $obj the resolved object to be modified
+     * @param LightContainerInterface $container the underlying container
+     * @return object the modified object
+     */
+    public function modify(object $obj, LightContainerInterface $container): object;
+}
+?>

--- a/src/Resolvers/BaseInstanceResolver.php
+++ b/src/Resolvers/BaseInstanceResolver.php
@@ -36,6 +36,7 @@
 namespace LightContainer\Resolvers;
 
 use LightContainer\LightContainerInterface;
+use LightContainer\InstanceModifierInterface;
 use LightContainer\NotFoundException;
 use LightContainer\Loader\LoadableInterface;
 use LightContainer\Loader\LoaderInterface;
@@ -223,21 +224,17 @@ class BaseInstanceResolver implements ResolverInterface, LoadableInterface {
     }
 
     /**
-     * Modifies the resolved object by passing it to a callable.
+     * Modifies the resolved object by passing it to a modifier.
      * 
-     * The callable is specified in the first parameter.  The callable receives
-     * the object that has been resolved and an instance of the container
-     * instance, and should return the modified object.  That is, the signature
-     * of the callable is as follows:
+     * The modifier is an object that implements {@link InstanceModifierInterface}.
+     * The {@link InstanceModifierInterface::modify()} method is called to
+     * return the modified object.
      * 
-     * ```
-     * function(object $obj, LightContainerInterface $container): object
-     * ```
-     * 
-     * @param callable|null $modifier callable to modify the resolved object
+     * @param InstanceModifierInterface|null $modifier the modifier
      * @return BaseInstanceResolver
+     * @see InstanceModifierInterface
      */
-    public function modify(?callable $modifier) {
+    public function modify(InstanceModifierInterface $modifier) {
         $this->options['modify'] = $modifier;
         return $this;
     }

--- a/src/Resolvers/BaseInstanceResolver.php
+++ b/src/Resolvers/BaseInstanceResolver.php
@@ -234,7 +234,7 @@ class BaseInstanceResolver implements ResolverInterface, LoadableInterface {
      * @return BaseInstanceResolver
      * @see InstanceModifierInterface
      */
-    public function modify(InstanceModifierInterface $modifier) {
+    public function modify(?InstanceModifierInterface $modifier) {
         $this->options['modify'] = $modifier;
         return $this;
     }

--- a/src/Resolvers/BaseInstanceResolver.php
+++ b/src/Resolvers/BaseInstanceResolver.php
@@ -71,7 +71,8 @@ class BaseInstanceResolver implements ResolverInterface, LoadableInterface {
         'propagate' => true,
         'alias' => [],
         'args' => [],
-        'call' => []
+        'call' => [],
+        'modify' => null
     ];
 
     /**
@@ -218,6 +219,26 @@ class BaseInstanceResolver implements ResolverInterface, LoadableInterface {
             'args' => $this->buildResolversFromArgs($args),
         ];
 
+        return $this;
+    }
+
+    /**
+     * Modifies the resolved object by passing it to a callable.
+     * 
+     * The callable is specified in the first parameter.  The callable receives
+     * the object that has been resolved and an instance of the container
+     * instance, and should return the modified object.  That is, the signature
+     * of the callable is as follows:
+     * 
+     * ```
+     * function(object $obj, LightContainerInterface $container): object
+     * ```
+     * 
+     * @param callable|null $modifier callable to modify the resolved object
+     * @return BaseInstanceResolver
+     */
+    public function modify(?callable $modifier) {
+        $this->options['modify'] = $modifier;
         return $this;
     }
 

--- a/src/Resolvers/ClassResolver.php
+++ b/src/Resolvers/ClassResolver.php
@@ -447,7 +447,7 @@ class ClassResolver extends BaseInstanceResolver implements AutowireInterface, T
         }
 
         if ($options['modify'] != null) {
-            $object = call_user_func($options['modify'], $object, $container);
+            $object = $options['modify']->modify($object, $container);
         }
         
         // 7. Save the object if it is shared

--- a/src/Resolvers/ClassResolver.php
+++ b/src/Resolvers/ClassResolver.php
@@ -445,11 +445,15 @@ class ClassResolver extends BaseInstanceResolver implements AutowireInterface, T
                 }, $this->cache['resolvers'][$method]));
             }
         }
+
+        if ($options['modify'] != null) {
+            $object = call_user_func($options['modify'], $object, $container);
+        }
         
-        // 6. Save the object if it is shared
+        // 7. Save the object if it is shared
         if ($options['shared']) $this->saveSharedObject($object);
 
-        // 7. Return the object
+        // 8. Return the object
         return $object;
     }
 

--- a/src/Resolvers/ReferenceResolver.php
+++ b/src/Resolvers/ReferenceResolver.php
@@ -136,7 +136,10 @@ class ReferenceResolver extends BaseInstanceResolver implements LoadableInterfac
      * @return bool true if custom instantiation options are set
      */
     public function hasCustomOptions(): bool {
-        return (!empty($this->options['alias']) || !empty($this->options['args']) || !empty($this->options['call']));
+        return (!empty($this->options['alias'])
+            || !empty($this->options['args'])
+            || !empty($this->options['call'])
+            || !empty($this->options['modify']));
     }
 
     /**

--- a/src/Resolvers/ReferenceResolver.php
+++ b/src/Resolvers/ReferenceResolver.php
@@ -191,9 +191,9 @@ class ReferenceResolver extends BaseInstanceResolver implements LoadableInterfac
             $resolver = clone $resolver;
             $resolver->setAutowired(false);
 
-            // Set options - only alias, args and call should be set
+            // Set options - only alias, args, call and modify should be set
             $options = array_filter($this->options, function ($v, $k) { 
-                return (in_array($k, ['alias', 'args', 'call']) && !empty($v)); 
+                return (in_array($k, ['alias', 'args', 'call', 'modify']) && !empty($v)); 
             }, ARRAY_FILTER_USE_BOTH);
 
             $resolver->setOptions($options);

--- a/tests/ModifyTest.php
+++ b/tests/ModifyTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace LightContainer\Tests;
+
+use LightContainer\Container;
+use LightContainer\LightContainerInterface;
+use LightContainer\InstanceModifierInterface;
+use PHPUnit\Framework\TestCase;
+
+/* -------------------------------------------------------------------------
+ * Mock
+ * ------------------------------------------------------------------------- */
+interface ModifyTestInterface {}
+
+class ModifyTestModifier implements InstanceModifierInterface {
+    public function modify(object $obj, LightContainerInterface $container): object {
+        $obj->modified = true;
+        return $obj;
+    }
+}
+
+class ModifyTestClass implements ModifyTestInterface {
+    public $modified;
+
+    public function __construct() {
+        $this->modified = false;
+    }
+}
+
+/* -------------------------------------------------------------------------
+ * Tests
+ * ------------------------------------------------------------------------- */
+class ModifyTest extends TestCase {
+    public function testModifyBasic() {
+        $container = new Container();
+        $modifier = new ModifyTestModifier();
+        $container->set(ModifyTestClass::class)->modify($modifier);
+        $obj = $container->get(ModifyTestClass::class);
+        $this->assertEquals($obj->modified, true);
+    }
+
+    public function testModifyReference() {
+        $container = new Container();
+        $modifier = new ModifyTestModifier();
+        $container->set(ModifyTestInterface::class, ModifyTestClass::class)->modify($modifier);
+
+        // If we resolve the class directly, it should not be passed to the modifier
+        $obj = $container->get(ModifyTestClass::class);
+        $this->assertEquals($obj->modified, false);
+
+        // If we resolve the interface, it should be passed to the modifier
+        $obj2 = $container->get(ModifyTestInterface::class);
+        $this->assertEquals($obj2->modified, true);
+    }
+}
+?>


### PR DESCRIPTION
Add `modify` option to modify resolved instances before they are returned by the container.

Fixes #3 