### PR TITLE
Change name of self resolver to LightContainerInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- The self resolver is attached to `LightContainerInterface` instead of
+  `Container`
+
 ## 0.2.0
 
 ### Added

--- a/src/Container.php
+++ b/src/Container.php
@@ -76,7 +76,7 @@ class Container implements LightContainerInterface {
 
     public function __construct() {
         $this->self_resolver = ValueResolver::create($this);
-        $this->set(self::class, $this->self_resolver);
+        $this->set(LightContainerInterface::class, $this->self_resolver);
         $this->set(LoaderInterface::class, Loader::class);
     }
     

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -3,6 +3,7 @@
 namespace LightContainer\Tests;
 
 use LightContainer\Container;
+use LightContainer\LightContainerInterface;
 use PHPUnit\Framework\TestCase;
 
 /* -------------------------------------------------------------------------
@@ -180,6 +181,12 @@ class BasicTest extends TestCase {
         $this->assertEquals(2, $paramHash['two']);
         $this->assertEquals(3, $paramHash['three']);
         $this->assertSame($obj, $container->get('@obj'));
+    }
+
+    // self
+    public function testSelfResolver() {
+        $container = new Container();
+        $this->assertSame($container, $container->get(LightContainerInterface::class));
     }
 }
 


### PR DESCRIPTION
Originally the container is set up to resolve `LightContainer\Container` to itself. However, it is more useful to resolve `LightContainer\LightContainerInterface` instead.